### PR TITLE
Fix formatting guide link and links to stats (there was 3 now down to 1)

### DIFF
--- a/views/mailingEdit.html
+++ b/views/mailingEdit.html
@@ -37,7 +37,7 @@
 		<p><strong>Last updated: </strong>{{updatedAt}}</p>
 		<form id="frmEdit" method="post" action="edit">
 			<h3>Email message</h3>
-			<p><a href="notification.alpha.canada.ca/features/templates">Email formating guide</a></p>
+			<p><a href="https://notification.alpha.canada.ca/features/templates">Email formating guide</a></p>
 			
 			<div class="form-horizontal">
 				<div class="form-group">

--- a/views/mailingManage.html
+++ b/views/mailingManage.html
@@ -35,9 +35,7 @@
 		<p style="color:red">There is no campaign.</p>
 	{{/mailings}}
 
-	{{#topics}}
-		<p><a href="stats">View subscriptions statistic by topic name</a></p>
-	{{/topics}}
+	<p><a href="stats">View subscriptions statistic by topic name</a></p>
 
 	<table border="1px" cellpadding="2px"> <!-- todo: Change how the table is styled -->
 		<thead>
@@ -50,8 +48,8 @@
 			{{#mailings}}
 				<tr>
 					<th><a href="{{ _id }}/edit">{{ topicId }} - {{ title }}</a></th>
-					<td>{{ state }}</th>
-					<td>{{ updatedAt }}{{^ updatedAt }}{{ createdAt }}{{/ updatedAt }}</th>
+					<td>{{ state }}</td>
+					<td>{{ updatedAt }}{{^ updatedAt }}{{ createdAt }}{{/ updatedAt }}</td>
 					<!--
 					<td>
 						<a href="{{ _id }}/delete">Delete</a>


### PR DESCRIPTION
As noticed during Mailing presentation dry-run.