### PR TITLE
Fix docs for REDIS_ENV env variable

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -127,7 +127,7 @@ Note: We need to set the Service ID associated to the topic details (field: `nSe
 
 
 ### REDIS Default Configuration
-* `REDIS_ENV` Set environment value for Redis. Default: `stage` and `production` which would leverage the redis-sentinel in production environment
+* `REDIS_ENV` Set environment value for Redis. Default: `stage` and `prod` which would leverage the redis-sentinel in production environment
 * `REDIS_URI` Redis URI, the alias or the IP of the server host. Default: `x-notify-redis`
 * `REDIS_PORT` Port of Redis server. Default: `6379`
 * `REDIS_SENTINEL_1_URI` Redis Sentinel 1 URI. Default: `127.0.0.1`


### PR DESCRIPTION
Fixing the docs for the value of `REDIS_ENV` .

See how it is implemented: https://github.com/ServiceCanada/x-notify/blob/master/controllers/subscriptions.js#L48