### PR TITLE
Fix typo in the field name for unconfirmed addition

### DIFF
--- a/controllers/subscriptions.js
+++ b/controllers/subscriptions.js
@@ -157,7 +157,7 @@ exports.addEmail = async ( req, res, next ) => {
 				subscode: confirmCode,
 				topicId: topicId,
 				notBefore: nBfDate.setMinutes( currDate.getMinutes() + _nbMinutesBF ),
-				createAt: currDate,
+				createdAt: currDate,
 				tId: tId,
 				nKey: nKey,
 				cURL: topic.confirmURL


### PR DESCRIPTION
Found when addressing APPS-157

This change would not impact any existing implementation. That field is only for reference purpose and that API end point is mostly used for testing.